### PR TITLE
Fixes #12 Added time-config to data builder.

### DIFF
--- a/data/src/main/java/nl/crashdata/chartjs/data/ChartJsAxisConfig.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/ChartJsAxisConfig.java
@@ -28,4 +28,7 @@ public interface ChartJsAxisConfig<T extends Serializable> extends Serializable
 
 	@JsonProperty("type")
 	ChartJsCartesianAxisType getType();
+
+	@JsonProperty("time")
+	ChartJsTimeConfig getTimeConfig();
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/ChartJsTimeConfig.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/ChartJsTimeConfig.java
@@ -1,0 +1,33 @@
+package nl.crashdata.chartjs.data;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents the time-specific configuration for a specific axis of the type 'time'.
+ *
+ * Corresponds to the elements of the {@code config.options.scales.xAxes[].time} and
+ * {@code config.options.scales.yAxes[].time} properties.
+ *
+ * @see "http://www.chartjs.org/docs/latest/axes/cartesian/time.html"
+ * @author haster
+ */
+public interface ChartJsTimeConfig extends Serializable
+{
+	/**
+	 * if {@code true}, Monday will be considered the first day of the week, otherwise it will be
+	 * Sunday. Only relevant if the unit is set to {@link ChartJsTimeUnit#WEEK}
+	 */
+	@JsonProperty("isoWeekday")
+	Boolean getIsoWeekday();
+
+	@JsonProperty("unit")
+	ChartJsTimeUnit getTimeUnit();
+
+	@JsonProperty("minUnit")
+	ChartJsTimeUnit getMinimumDisplayUnit();
+
+	@JsonProperty("stepSize")
+	Number getStepSize();
+}

--- a/data/src/main/java/nl/crashdata/chartjs/data/ChartJsTimeUnit.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/ChartJsTimeUnit.java
@@ -1,0 +1,33 @@
+package nl.crashdata.chartjs.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ChartJsTimeUnit
+{
+	@JsonProperty("millisecond")
+	MILLISECOND,
+
+	@JsonProperty("second")
+	SECOND,
+
+	@JsonProperty("minute")
+	MINUTE,
+
+	@JsonProperty("hour")
+	HOUR,
+
+	@JsonProperty("day")
+	DAY,
+
+	@JsonProperty("week")
+	WEEK,
+
+	@JsonProperty("month")
+	MONTH,
+
+	@JsonProperty("quarter")
+	QUARTER,
+
+	@JsonProperty("year")
+	YEAR;
+}

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/SimpleChartJsAxisConfig.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/SimpleChartJsAxisConfig.java
@@ -7,6 +7,7 @@ import nl.crashdata.chartjs.data.ChartJsAxisPosition;
 import nl.crashdata.chartjs.data.ChartJsCartesianAxisType;
 import nl.crashdata.chartjs.data.ChartJsScaleLabelConfig;
 import nl.crashdata.chartjs.data.ChartJsTickConfig;
+import nl.crashdata.chartjs.data.ChartJsTimeConfig;
 
 public class SimpleChartJsAxisConfig<T extends Serializable> implements ChartJsAxisConfig<T>
 {
@@ -21,6 +22,8 @@ public class SimpleChartJsAxisConfig<T extends Serializable> implements ChartJsA
 	private ChartJsAxisPosition position;
 
 	private ChartJsCartesianAxisType type;
+
+	private ChartJsTimeConfig timeConfig;
 
 	@Override
 	public Boolean isDisplay()
@@ -75,5 +78,16 @@ public class SimpleChartJsAxisConfig<T extends Serializable> implements ChartJsA
 	public void setType(ChartJsCartesianAxisType type)
 	{
 		this.type = type;
+	}
+
+	@Override
+	public ChartJsTimeConfig getTimeConfig()
+	{
+		return timeConfig;
+	}
+
+	public void setTimeConfig(ChartJsTimeConfig timeConfig)
+	{
+		this.timeConfig = timeConfig;
 	}
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/SimpleChartJsTimeConfig.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/SimpleChartJsTimeConfig.java
@@ -1,0 +1,61 @@
+package nl.crashdata.chartjs.data.simple;
+
+import nl.crashdata.chartjs.data.ChartJsTimeConfig;
+import nl.crashdata.chartjs.data.ChartJsTimeUnit;
+
+public class SimpleChartJsTimeConfig implements ChartJsTimeConfig
+{
+	private static final long serialVersionUID = 1L;
+
+	private Boolean isoWeekday;
+
+	private ChartJsTimeUnit timeUnit;
+
+	private ChartJsTimeUnit minimumDisplayUnit;
+
+	private Number stepSize;
+
+	@Override
+	public Boolean getIsoWeekday()
+	{
+		return isoWeekday;
+	}
+
+	public void setIsoWeekday(Boolean isoWeekday)
+	{
+		this.isoWeekday = isoWeekday;
+	}
+
+	@Override
+	public ChartJsTimeUnit getTimeUnit()
+	{
+		return timeUnit;
+	}
+
+	public void setTimeUnit(ChartJsTimeUnit timeUnit)
+	{
+		this.timeUnit = timeUnit;
+	}
+
+	@Override
+	public ChartJsTimeUnit getMinimumDisplayUnit()
+	{
+		return minimumDisplayUnit;
+	}
+
+	public void setMinimumDisplayUnit(ChartJsTimeUnit minimumDisplayUnit)
+	{
+		this.minimumDisplayUnit = minimumDisplayUnit;
+	}
+
+	@Override
+	public Number getStepSize()
+	{
+		return stepSize;
+	}
+
+	public void setStepSize(Number stepSize)
+	{
+		this.stepSize = stepSize;
+	}
+}

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/AbstractSimpleChartJsAxisConfigBuilder.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/AbstractSimpleChartJsAxisConfigBuilder.java
@@ -19,6 +19,8 @@ public abstract class AbstractSimpleChartJsAxisConfigBuilder<T extends Serializa
 	private SimpleChartJsScaleLabelConfigBuilder labelConfigBuilder =
 		new SimpleChartJsScaleLabelConfigBuilder();
 
+	private SimpleChartJsTimeConfigBuilder timeConfigBuilder;
+
 	protected AbstractSimpleChartJsAxisConfigBuilder(ChartJsCartesianAxisType type)
 	{
 		this.type = type;
@@ -45,11 +47,21 @@ public abstract class AbstractSimpleChartJsAxisConfigBuilder<T extends Serializa
 			AbstractSimpleChartJsTickConfigBuilder<T, ? extends AbstractSimpleChartJsTickConfig<T>>
 			tickConfig();
 
+	protected SimpleChartJsTimeConfigBuilder timeConfig()
+	{
+		return timeConfigBuilder;
+	}
+
+	protected void setTimeConfigBuilder(SimpleChartJsTimeConfigBuilder timeConfigBuilder)
+	{
+		this.timeConfigBuilder = timeConfigBuilder;
+	}
+
 	@Override
 	public boolean isValid()
 	{
 		return position != null && type != null && labelConfigBuilder.isValid()
-			&& tickConfig().isValid();
+			&& tickConfig().isValid() && (timeConfigBuilder == null || timeConfigBuilder.isValid());
 	}
 
 	@Override
@@ -65,6 +77,8 @@ public abstract class AbstractSimpleChartJsAxisConfigBuilder<T extends Serializa
 		ret.setType(type);
 		ret.setLabelConfig(labelConfigBuilder.build());
 		ret.setTickConfig(tickConfig().build());
+		if (timeConfigBuilder != null)
+			ret.setTimeConfig(timeConfigBuilder.build());
 		return ret;
 	}
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsInstantAxisConfigBuilder.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsInstantAxisConfigBuilder.java
@@ -13,11 +13,18 @@ public class SimpleChartJsInstantAxisConfigBuilder
 	public SimpleChartJsInstantAxisConfigBuilder()
 	{
 		super(ChartJsCartesianAxisType.TIME);
+		setTimeConfigBuilder(new SimpleChartJsTimeConfigBuilder());
 	}
 
 	@Override
 	public SimpleChartJsTemporalTickConfigBuilder<Instant> tickConfig()
 	{
 		return tickConfigBuilder;
+	}
+
+	@Override
+	public SimpleChartJsTimeConfigBuilder timeConfig()
+	{
+		return super.timeConfig();
 	}
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsLocalDateAxisConfigBuilder.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsLocalDateAxisConfigBuilder.java
@@ -13,11 +13,18 @@ public class SimpleChartJsLocalDateAxisConfigBuilder
 	public SimpleChartJsLocalDateAxisConfigBuilder()
 	{
 		super(ChartJsCartesianAxisType.TIME);
+		setTimeConfigBuilder(new SimpleChartJsTimeConfigBuilder());
 	}
 
 	@Override
 	public SimpleChartJsTemporalTickConfigBuilder<LocalDate> tickConfig()
 	{
 		return tickConfigBuilder;
+	}
+
+	@Override
+	public SimpleChartJsTimeConfigBuilder timeConfig()
+	{
+		return super.timeConfig();
 	}
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsLocalDateTimeAxisConfigBuilder.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsLocalDateTimeAxisConfigBuilder.java
@@ -13,11 +13,18 @@ public class SimpleChartJsLocalDateTimeAxisConfigBuilder
 	public SimpleChartJsLocalDateTimeAxisConfigBuilder()
 	{
 		super(ChartJsCartesianAxisType.TIME);
+		setTimeConfigBuilder(new SimpleChartJsTimeConfigBuilder());
 	}
 
 	@Override
 	public SimpleChartJsTemporalTickConfigBuilder<LocalDateTime> tickConfig()
 	{
 		return tickConfigBuilder;
+	}
+
+	@Override
+	public SimpleChartJsTimeConfigBuilder timeConfig()
+	{
+		return super.timeConfig();
 	}
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsLocalTimeAxisConfigBuilder.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsLocalTimeAxisConfigBuilder.java
@@ -13,11 +13,18 @@ public class SimpleChartJsLocalTimeAxisConfigBuilder
 	public SimpleChartJsLocalTimeAxisConfigBuilder()
 	{
 		super(ChartJsCartesianAxisType.TIME);
+		setTimeConfigBuilder(new SimpleChartJsTimeConfigBuilder());
 	}
 
 	@Override
 	public SimpleChartJsTemporalTickConfigBuilder<LocalTime> tickConfig()
 	{
 		return tickConfigBuilder;
+	}
+
+	@Override
+	public SimpleChartJsTimeConfigBuilder timeConfig()
+	{
+		return super.timeConfig();
 	}
 }

--- a/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsTimeConfigBuilder.java
+++ b/data/src/main/java/nl/crashdata/chartjs/data/simple/builder/SimpleChartJsTimeConfigBuilder.java
@@ -1,0 +1,67 @@
+package nl.crashdata.chartjs.data.simple.builder;
+
+import nl.crashdata.chartjs.data.ChartJsTimeConfig;
+import nl.crashdata.chartjs.data.ChartJsTimeUnit;
+import nl.crashdata.chartjs.data.simple.SimpleChartJsTimeConfig;
+
+public class SimpleChartJsTimeConfigBuilder implements SimpleChartJsBuilder<ChartJsTimeConfig>
+{
+	private Boolean isoWeekday;
+
+	private ChartJsTimeUnit timeUnit;
+
+	private ChartJsTimeUnit minimumDisplayUnit;
+
+	private Number stepSize;
+
+	/**
+	 * @param isoWeekday
+	 *            if {@code true}, the week starts on Monday, otherwise it starts on Sunday. Only
+	 *            relevant if {@link #withTimeUnit(ChartJsTimeUnit)} is set to
+	 *            {@link ChartJsTimeUnit#WEEK}
+	 */
+	public SimpleChartJsTimeConfigBuilder withIsoWeekday(Boolean isoWeekday)
+	{
+		this.isoWeekday = isoWeekday;
+		return this;
+	}
+
+	public SimpleChartJsTimeConfigBuilder withStepSize(Number stepSize)
+	{
+		this.stepSize = stepSize;
+		return this;
+	}
+
+	public SimpleChartJsTimeConfigBuilder withTimeUnit(ChartJsTimeUnit timeUnit)
+	{
+		this.timeUnit = timeUnit;
+		return this;
+	}
+
+	public SimpleChartJsTimeConfigBuilder withMinimumDisplayUnit(ChartJsTimeUnit minimumDisplayUnit)
+	{
+		this.minimumDisplayUnit = minimumDisplayUnit;
+		return this;
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return true;
+	}
+
+	@Override
+	public ChartJsTimeConfig build() throws IllegalStateException
+	{
+		if (!isValid())
+		{
+			throw new IllegalStateException(getClass().getSimpleName() + " is not ready to build!");
+		}
+		SimpleChartJsTimeConfig ret = new SimpleChartJsTimeConfig();
+		ret.setIsoWeekday(isoWeekday);
+		ret.setTimeUnit(timeUnit);
+		ret.setMinimumDisplayUnit(minimumDisplayUnit);
+		ret.setStepSize(stepSize);
+		return ret;
+	}
+}


### PR DESCRIPTION
Time-config describes settings specific to time-axes, such as the unit
to use.